### PR TITLE
DEV-1454 Create a private key for generated service account and delete

### DIFF
--- a/src/main/java/com/hartwig/platinum/Platinum.java
+++ b/src/main/java/com/hartwig/platinum/Platinum.java
@@ -6,8 +6,10 @@ import com.google.api.services.cloudresourcemanager.CloudResourceManager;
 import com.google.api.services.iam.v1.Iam;
 import com.google.cloud.storage.Storage;
 import com.hartwig.platinum.config.PlatinumConfiguration;
+import com.hartwig.platinum.iam.JsonKey;
 import com.hartwig.platinum.iam.PipelineIamPolicy;
 import com.hartwig.platinum.iam.PipelineServiceAccount;
+import com.hartwig.platinum.iam.ServiceAccountPrivateKey;
 import com.hartwig.platinum.kubernetes.KubernetesCluster;
 import com.hartwig.platinum.storage.OutputBucket;
 
@@ -34,9 +36,14 @@ public class Platinum {
         PlatinumConfiguration configuration = PlatinumConfiguration.from(new File(input));
         PipelineServiceAccount serviceAccount = new PipelineServiceAccount(iam, new PipelineIamPolicy(resourceManager));
         String serviceAccountEmail = serviceAccount.findOrCreate(project, runName);
+        ServiceAccountPrivateKey privateKey = new ServiceAccountPrivateKey(iam);
+        JsonKey keyJson = privateKey.create(project, serviceAccountEmail);
+
         KubernetesCluster cluster = KubernetesCluster.findOrCreate(runName,
                 OutputBucket.from(storage).findOrCreate(runName, configuration.outputConfiguration()));
         cluster.submit(configuration);
+
+        privateKey.delete(keyJson);
         serviceAccount.delete(project, serviceAccountEmail);
     }
 }

--- a/src/main/java/com/hartwig/platinum/iam/JsonKey.java
+++ b/src/main/java/com/hartwig/platinum/iam/JsonKey.java
@@ -1,0 +1,17 @@
+package com.hartwig.platinum.iam;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface JsonKey {
+
+    @Value.Parameter
+    String id();
+
+    @Value.Parameter
+    String jsonBase64();
+
+    static JsonKey of(final String id, final String json) {
+        return ImmutableJsonKey.of(id, json);
+    }
+}

--- a/src/main/java/com/hartwig/platinum/iam/PipelineServiceAccount.java
+++ b/src/main/java/com/hartwig/platinum/iam/PipelineServiceAccount.java
@@ -20,7 +20,7 @@ public class PipelineServiceAccount {
 
     public String findOrCreate(final String project, final String runName) {
         try {
-            String serviceAccountName = ServiceAccountName.from(project, runName);
+            String serviceAccountName = ServiceAccountName.from(runName);
             String projectResourceName = "projects/" + project;
             List<ServiceAccount> accounts = projectServiceAccounts(iam, projectResourceName);
             ServiceAccount serviceAccount = accounts != null ? accounts.stream()

--- a/src/main/java/com/hartwig/platinum/iam/ServiceAccountId.java
+++ b/src/main/java/com/hartwig/platinum/iam/ServiceAccountId.java
@@ -1,0 +1,8 @@
+package com.hartwig.platinum.iam;
+
+public class ServiceAccountId {
+
+    static String from(final String project, final String email) {
+        return String.format("projects/%s/serviceAccounts/%s", project, email);
+    }
+}

--- a/src/main/java/com/hartwig/platinum/iam/ServiceAccountName.java
+++ b/src/main/java/com/hartwig/platinum/iam/ServiceAccountName.java
@@ -2,7 +2,7 @@ package com.hartwig.platinum.iam;
 
 public class ServiceAccountName {
 
-    static String from(final String project, final String runName) {
+    static String from(final String runName) {
         return "platinum-" + runName;
     }
 }

--- a/src/main/java/com/hartwig/platinum/iam/ServiceAccountPrivateKey.java
+++ b/src/main/java/com/hartwig/platinum/iam/ServiceAccountPrivateKey.java
@@ -1,0 +1,37 @@
+package com.hartwig.platinum.iam;
+
+import java.io.IOException;
+
+import com.google.api.services.iam.v1.Iam;
+import com.google.api.services.iam.v1.model.CreateServiceAccountKeyRequest;
+import com.google.api.services.iam.v1.model.ServiceAccountKey;
+
+public class ServiceAccountPrivateKey {
+
+    private final Iam iam;
+
+    public ServiceAccountPrivateKey(final Iam iam) {
+        this.iam = iam;
+    }
+
+    public JsonKey create(final String project, final String email) {
+        try {
+            ServiceAccountKey key = iam.projects()
+                    .serviceAccounts()
+                    .keys()
+                    .create(ServiceAccountId.from(project, email), new CreateServiceAccountKeyRequest())
+                    .execute();
+            return JsonKey.of(key.getName(), key.getPrivateKeyData());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void delete(final JsonKey key) {
+        try {
+            iam.projects().serviceAccounts().keys().delete(key.id()).execute();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/hartwig/platinum/iam/ServiceAccountPrivateKeyTest.java
+++ b/src/test/java/com/hartwig/platinum/iam/ServiceAccountPrivateKeyTest.java
@@ -1,0 +1,56 @@
+package com.hartwig.platinum.iam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.services.iam.v1.Iam;
+import com.google.api.services.iam.v1.model.CreateServiceAccountKeyRequest;
+import com.google.api.services.iam.v1.model.ServiceAccountKey;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServiceAccountPrivateKeyTest {
+
+    public static final String PROJECT = "project";
+    public static final String EMAIL = "service-account@service-account.com";
+    public static final String DATA = "data";
+    public static final String NAME = "name";
+    private ServiceAccountPrivateKey victim;
+    private Iam.Projects.ServiceAccounts.Keys serviceAccountsKeys;
+    private Iam.Projects.ServiceAccounts.Keys.Create serviceAccountKeyCreate;
+
+    @Before
+    public void setUp() {
+        final Iam iam = mock(Iam.class);
+        Iam.Projects projects = mock(Iam.Projects.class);
+        Iam.Projects.ServiceAccounts serviceAccounts = mock(Iam.Projects.ServiceAccounts.class);
+        serviceAccountsKeys = mock(Iam.Projects.ServiceAccounts.Keys.class);
+        serviceAccountKeyCreate = mock(Iam.Projects.ServiceAccounts.Keys.Create.class);
+        when(iam.projects()).thenReturn(projects);
+        when(projects.serviceAccounts()).thenReturn(serviceAccounts);
+        when(serviceAccounts.keys()).thenReturn(serviceAccountsKeys);
+        victim = new ServiceAccountPrivateKey(iam);
+    }
+
+    @Test
+    public void createsAndReturnsContentAndName() throws Exception {
+        ServiceAccountKey serviceAccountKey = new ServiceAccountKey().setName(NAME).setPrivateKeyData(DATA);
+        when(serviceAccountsKeys.create(ServiceAccountId.from(PROJECT, EMAIL), new CreateServiceAccountKeyRequest())).thenReturn(
+                serviceAccountKeyCreate);
+        when(serviceAccountKeyCreate.execute()).thenReturn(serviceAccountKey);
+        JsonKey key = victim.create(PROJECT, EMAIL);
+        assertThat(key.id()).isEqualTo(NAME);
+        assertThat(key.jsonBase64()).isEqualTo(DATA);
+    }
+
+    @Test
+    public void deletesKeyWithName() throws Exception {
+        Iam.Projects.ServiceAccounts.Keys.Delete serviceAccountsKeysDelete = mock(Iam.Projects.ServiceAccounts.Keys.Delete.class);
+        when(serviceAccountsKeys.delete(NAME)).thenReturn(serviceAccountsKeysDelete);
+        victim.delete(JsonKey.of(NAME, DATA));
+        verify(serviceAccountsKeysDelete).execute();
+    }
+}


### PR DESCRIPTION
The key is created and extracted from the API as base64 (this will play nice when
we want to create the secret).

When complete, the key is deleted before the service account is deleted.