### PR TITLE
DEV-1631 Add option to use existing service account key

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,23 @@ Notes:
 }
 ```
 
+### Running with an existing cluster
+
+Platinum uses ephemeral infrastructure to ease any maintenance burden, hide complexity and reduce resource contention. That said, you may 
+want to use existing shared infrastructure for your platinum runs.
+
+To set this up you can pass platinum an existing service account name, cluster name and secret within that cluster which contains the 
+private key for the service account like so:
+
+```json
+{
+"serviceAccount":{
+    "name": "you-sa@your-sa.iam.gserviceaccount.com",
+    "existingSecret": "secret"
+  "cluster": "your-cluster"
+}
+``` 
+
 ### Additional GCP Configuration
 
 Platinum offers some additional configuration options to suit more complex GCP project setups. These extra settings are mainly geared for 

--- a/examples/hmf/rerun.json
+++ b/examples/hmf/rerun.json
@@ -1,0 +1,17 @@
+{
+  "serviceAccount":{
+    "name": "hmf-crunch@hmf-crunch.iam.gserviceaccount.com",
+    "existingSecret": "service-account-key"
+  },
+  "cluster": "rerun-cluster",
+  "image": "eu.gcr.io/hmf-images/pipeline5:5.?.?",
+  "cmek": "",
+  "apiUrl": "https://api.hartwigmedicalfoundation.nl",
+  "keystorePassword": "",
+  "argumentOverrides": {
+    "starting_point": ""
+  },
+  "biopsies": [
+    ""
+  ]
+}

--- a/platinum
+++ b/platinum
@@ -63,7 +63,7 @@ function cleanup() {
         exit 1
     fi
     service_account="platinum-${1}@${2}.iam.gserviceaccount.com"
-    gcloud container clusters delete $1-cluster --region $region --project $2
+    gcloud container clusters delete $1 --region $region --project $2
     for role in iam.serviceAccountUser compute.admin storage.admin; do
         gcloud projects remove-iam-policy-binding $2 --member=serviceAccount:$service_account --role=roles/${role} >/dev/null
     done

--- a/src/main/java/com/hartwig/platinum/Platinum.java
+++ b/src/main/java/com/hartwig/platinum/Platinum.java
@@ -47,14 +47,14 @@ public class Platinum {
         PipelineServiceAccount serviceAccount =
                 PipelineServiceAccount.from(iam, resourceManager, runName, gcpConfiguration.projectOrThrow(), configuration);
         String serviceAccountEmail = serviceAccount.findOrCreate();
-        ServiceAccountPrivateKey privateKey = new ServiceAccountPrivateKey(iam);
+        ServiceAccountPrivateKey privateKey = ServiceAccountPrivateKey.from(configuration, iam);
         JsonKey jsonKey = privateKey.create(gcpConfiguration.projectOrThrow(), serviceAccountEmail);
         List<Job> submitted = kubernetesEngine.findOrCreate(runName,
                 configuration,
                 jsonKey,
                 OutputBucket.from(storage).findOrCreate(runName, gcpConfiguration.regionOrThrow(), serviceAccountEmail, configuration),
                 serviceAccountEmail).submit(configuration);
-        LOGGER.info("Platinum started [{}] pipelines on GCP", submitted.size());
+        LOGGER.info("Platinum started {} pipelines on GCP", Console.bold(String.valueOf(submitted.size())));
         LOGGER.info("You can monitor their progress with: {}", Console.bold("./platinum status"));
     }
 }

--- a/src/main/java/com/hartwig/platinum/config/PlatinumConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/PlatinumConfiguration.java
@@ -33,8 +33,8 @@ public interface PlatinumConfiguration {
 
     Optional<String> cmek();
 
-    Optional<String> serviceAccount();
-
+    Optional<ServiceAccountConfiguration> serviceAccount();
+    
     Optional<String> cluster();
 
     Optional<String> apiUrl();

--- a/src/main/java/com/hartwig/platinum/config/ServiceAccountConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/ServiceAccountConfiguration.java
@@ -1,0 +1,16 @@
+package com.hartwig.platinum.config;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+
+@JsonDeserialize(as = ImmutableServiceAccountConfiguration.class)
+@Value.Immutable
+public interface ServiceAccountConfiguration {
+
+    String name();
+
+    Optional<String> existingSecret();
+}

--- a/src/main/java/com/hartwig/platinum/iam/EphemeralPipelineServiceAccount.java
+++ b/src/main/java/com/hartwig/platinum/iam/EphemeralPipelineServiceAccount.java
@@ -8,14 +8,14 @@ import com.google.api.services.iam.v1.model.CreateServiceAccountRequest;
 import com.google.api.services.iam.v1.model.ListServiceAccountsResponse;
 import com.google.api.services.iam.v1.model.ServiceAccount;
 
-public class TransientPipelineServiceAccount implements PipelineServiceAccount {
+public class EphemeralPipelineServiceAccount implements PipelineServiceAccount {
 
     private final Iam iam;
     private final PipelineIamPolicy policy;
     private final String runName;
     private final String project;
 
-    public TransientPipelineServiceAccount(final Iam iam, final PipelineIamPolicy policy, final String runName, final String project) {
+    public EphemeralPipelineServiceAccount(final Iam iam, final PipelineIamPolicy policy, final String runName, final String project) {
         this.iam = iam;
         this.policy = policy;
         this.runName = runName;

--- a/src/main/java/com/hartwig/platinum/iam/EphemeralServiceAccountPrivateKey.java
+++ b/src/main/java/com/hartwig/platinum/iam/EphemeralServiceAccountPrivateKey.java
@@ -1,0 +1,29 @@
+package com.hartwig.platinum.iam;
+
+import java.io.IOException;
+
+import com.google.api.services.iam.v1.Iam;
+import com.google.api.services.iam.v1.model.CreateServiceAccountKeyRequest;
+import com.google.api.services.iam.v1.model.ServiceAccountKey;
+
+public class EphemeralServiceAccountPrivateKey implements ServiceAccountPrivateKey {
+
+    private final Iam iam;
+
+    public EphemeralServiceAccountPrivateKey(final Iam iam) {
+        this.iam = iam;
+    }
+
+    public JsonKey create(final String project, final String email) {
+        try {
+            ServiceAccountKey key = iam.projects()
+                    .serviceAccounts()
+                    .keys()
+                    .create(ServiceAccountId.from(project, email), new CreateServiceAccountKeyRequest())
+                    .execute();
+            return JsonKey.of(key.getPrivateKeyData());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/hartwig/platinum/iam/JsonKey.java
+++ b/src/main/java/com/hartwig/platinum/iam/JsonKey.java
@@ -5,13 +5,23 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface JsonKey {
 
-    @Value.Parameter
-    String id();
+    @Value.Default
+    default boolean secretExists() {
+        return false;
+    }
 
-    @Value.Parameter
+    @Value.Default
+    default String secretName() {
+        return "service-account-key";
+    }
+
     String jsonBase64();
 
-    static JsonKey of(final String id, final String json) {
-        return ImmutableJsonKey.of(id, json);
+    static JsonKey existing(final String secret) {
+        return ImmutableJsonKey.builder().secretName(secret).secretExists(true).jsonBase64("").build();
+    }
+
+    static JsonKey of(final String json) {
+        return ImmutableJsonKey.builder().jsonBase64(json).build();
     }
 }

--- a/src/main/java/com/hartwig/platinum/iam/PipelineServiceAccount.java
+++ b/src/main/java/com/hartwig/platinum/iam/PipelineServiceAccount.java
@@ -15,13 +15,13 @@ public interface PipelineServiceAccount {
         return configuration.serviceAccount().<PipelineServiceAccount>map(s -> new PipelineServiceAccount() {
             @Override
             public String findOrCreate() {
-                return s;
+                return s.name();
             }
 
             @Override
             public void delete(final String email) {
                 // do nothing
             }
-        }).orElse(new TransientPipelineServiceAccount(iam, new PipelineIamPolicy(cloudResourceManager), runName, project));
+        }).orElse(new EphemeralPipelineServiceAccount(iam, new PipelineIamPolicy(cloudResourceManager), runName, project));
     }
 }

--- a/src/main/java/com/hartwig/platinum/kubernetes/JobScheduler.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/JobScheduler.java
@@ -2,6 +2,8 @@ package com.hartwig.platinum.kubernetes;
 
 import static com.hartwig.platinum.kubernetes.KubernetesCluster.NAMESPACE;
 
+import com.hartwig.platinum.Console;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +24,7 @@ public class JobScheduler {
         JobSpec spec = job.asKubernetes();
         Boolean delete = kubernetesClient.batch().jobs().inNamespace(NAMESPACE).withName(job.getName()).delete();
         if (delete) {
-            LOGGER.info("Delete existing job [{}]", job.getName());
+            LOGGER.info("Delete existing job {}", Console.bold(job.getName()));
         }
         return kubernetesClient.batch()
                 .jobs()

--- a/src/main/java/com/hartwig/platinum/kubernetes/KubernetesEngine.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/KubernetesEngine.java
@@ -138,7 +138,7 @@ public class KubernetesEngine {
             return new KubernetesCluster(runName,
                     new JobScheduler(kubernetesClient),
                     new PipelineServiceAccountSecretVolume(jsonKey, kubernetesClient, "service-account-key"),
-                    new PipelineConfigMapVolume(configuration, kubernetesClient),
+                    new PipelineConfigMapVolume(configuration, kubernetesClient, runName),
                     outputBucketName,
                     serviceAccountEmail);
         } catch (Exception e) {

--- a/src/main/java/com/hartwig/platinum/kubernetes/PipelineConfigMapVolume.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/PipelineConfigMapVolume.java
@@ -12,26 +12,30 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 
 public class PipelineConfigMapVolume implements KubernetesComponent<Volume> {
 
-    private static final String SAMPLE = "sample";
+    private static final String SAMPLES = "samples";
     private final PlatinumConfiguration configuration;
     private final KubernetesClient kubernetesClient;
+    private final String runName;
 
-    public PipelineConfigMapVolume(final PlatinumConfiguration configuration, final KubernetesClient kubernetesClient) {
+    public PipelineConfigMapVolume(final PlatinumConfiguration configuration, final KubernetesClient kubernetesClient,
+            final String runName) {
         this.configuration = configuration;
         this.kubernetesClient = kubernetesClient;
+        this.runName = runName;
     }
 
     public Volume asKubernetes() {
+        String name = runName + "-" + SAMPLES;
         kubernetesClient.configMaps()
                 .inNamespace(KubernetesCluster.NAMESPACE)
-                .withName(SAMPLE)
+                .withName(name)
                 .createOrReplaceWithNew()
                 .addToData(configuration.samples().entrySet().stream().collect(toMap(Entry::getKey, e -> e.getValue().toString())))
                 .withNewMetadata()
-                .withName(SAMPLE)
+                .withName(name)
                 .withNamespace(KubernetesCluster.NAMESPACE)
                 .endMetadata()
                 .done();
-        return new VolumeBuilder().withName(SAMPLE).editOrNewConfigMap().withName(SAMPLE).endConfigMap().build();
+        return new VolumeBuilder().withName(name).editOrNewConfigMap().withName(name).endConfigMap().build();
     }
 }

--- a/src/main/java/com/hartwig/platinum/kubernetes/PipelineServiceAccountSecretVolume.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/PipelineServiceAccountSecretVolume.java
@@ -18,16 +18,18 @@ public class PipelineServiceAccountSecretVolume implements KubernetesComponent<V
     }
 
     public Volume asKubernetes() {
-        kubernetesClient.secrets()
-                .inNamespace(KubernetesCluster.NAMESPACE)
-                .withName(name)
-                .createOrReplaceWithNew()
-                .addToData(name, jsonKey.jsonBase64())
-                .withNewMetadata()
-                .withName(name)
-                .withNamespace(KubernetesCluster.NAMESPACE)
-                .endMetadata()
-                .done();
+        if (!jsonKey.secretExists()) {
+            kubernetesClient.secrets()
+                    .inNamespace(KubernetesCluster.NAMESPACE)
+                    .withName(name)
+                    .createOrReplaceWithNew()
+                    .addToData(name, jsonKey.jsonBase64())
+                    .withNewMetadata()
+                    .withName(name)
+                    .withNamespace(KubernetesCluster.NAMESPACE)
+                    .endMetadata()
+                    .done();
+        }
         return new VolumeBuilder().withName(name).editOrNewSecret().withSecretName(name).endSecret().build();
     }
 }

--- a/src/test/java/com/hartwig/platinum/iam/EphemeralPipelineServiceAccountTest.java
+++ b/src/test/java/com/hartwig/platinum/iam/EphemeralPipelineServiceAccountTest.java
@@ -18,14 +18,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-public class TransientPipelineServiceAccountTest {
+public class EphemeralPipelineServiceAccountTest {
 
     private static final String SERVICE_ACCOUNT_NAME = "platinum-test";
     private static final String EMAIL = SERVICE_ACCOUNT_NAME + "@service-account.com";
     private static final String PROJECT = "hmf-test";
     private static final String PROJECT_RESOURCE_NAME = "projects/" + PROJECT;
     private static final String RUN_NAME = "test";
-    private TransientPipelineServiceAccount victim;
+    private EphemeralPipelineServiceAccount victim;
     private ArgumentCaptor<String> projectArgumentCaptor;
     private ArgumentCaptor<CreateServiceAccountRequest> createServiceAccountRequestArgumentCaptor;
     private ListServiceAccountsResponse listServiceAccountsResponse;
@@ -55,7 +55,7 @@ public class TransientPipelineServiceAccountTest {
         when(serviceAccount.getEmail()).thenReturn(EMAIL);
 
         iamPolicy = mock(PipelineIamPolicy.class);
-        victim = new TransientPipelineServiceAccount(iam, iamPolicy, RUN_NAME, PROJECT);
+        victim = new EphemeralPipelineServiceAccount(iam, iamPolicy, RUN_NAME, PROJECT);
     }
 
     @Test

--- a/src/test/java/com/hartwig/platinum/iam/EphemeralServiceAccountPrivateKeyTest.java
+++ b/src/test/java/com/hartwig/platinum/iam/EphemeralServiceAccountPrivateKeyTest.java
@@ -2,7 +2,6 @@ package com.hartwig.platinum.iam;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.services.iam.v1.Iam;
@@ -12,13 +11,13 @@ import com.google.api.services.iam.v1.model.ServiceAccountKey;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ServiceAccountPrivateKeyTest {
+public class EphemeralServiceAccountPrivateKeyTest {
 
     public static final String PROJECT = "project";
     public static final String EMAIL = "service-account@service-account.com";
     public static final String DATA = "data";
     public static final String NAME = "name";
-    private ServiceAccountPrivateKey victim;
+    private EphemeralServiceAccountPrivateKey victim;
     private Iam.Projects.ServiceAccounts.Keys serviceAccountsKeys;
     private Iam.Projects.ServiceAccounts.Keys.Create serviceAccountKeyCreate;
 
@@ -32,7 +31,7 @@ public class ServiceAccountPrivateKeyTest {
         when(iam.projects()).thenReturn(projects);
         when(projects.serviceAccounts()).thenReturn(serviceAccounts);
         when(serviceAccounts.keys()).thenReturn(serviceAccountsKeys);
-        victim = new ServiceAccountPrivateKey(iam);
+        victim = new EphemeralServiceAccountPrivateKey(iam);
     }
 
     @Test
@@ -42,15 +41,6 @@ public class ServiceAccountPrivateKeyTest {
                 serviceAccountKeyCreate);
         when(serviceAccountKeyCreate.execute()).thenReturn(serviceAccountKey);
         JsonKey key = victim.create(PROJECT, EMAIL);
-        assertThat(key.id()).isEqualTo(NAME);
-        assertThat(key.jsonBase64()).isEqualTo(DATA);
-    }
-
-    @Test
-    public void deletesKeyWithName() throws Exception {
-        Iam.Projects.ServiceAccounts.Keys.Delete serviceAccountsKeysDelete = mock(Iam.Projects.ServiceAccounts.Keys.Delete.class);
-        when(serviceAccountsKeys.delete(NAME)).thenReturn(serviceAccountsKeysDelete);
-        victim.delete(JsonKey.of(NAME, DATA));
-        verify(serviceAccountsKeysDelete).execute();
+         assertThat(key.jsonBase64()).isEqualTo(DATA);
     }
 }

--- a/src/test/java/com/hartwig/platinum/kubernetes/KubernetesEngineTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/KubernetesEngineTest.java
@@ -46,7 +46,7 @@ public class KubernetesEngineTest {
     public static final String RUN_NAME = "runName";
     public static final String BUCKET = "bucket";
     public static final String SERVICE_ACCOUNT = "service_account";
-    public static final JsonKey JSON_KEY = JsonKey.of("id", "json");
+    public static final JsonKey JSON_KEY = JsonKey.of("json");
     private Locations locations;
     private Clusters clusters;
     private ProcessRunner processRunner;


### PR DESCRIPTION
Users can now configure an existing secret name in the JSON. When present, platinum will not
create a new private key or new secret, and use the existing secret.

The logic to delete service account keys is also deleted, as it was never used.