### PR TITLE
DEV-1655 Adjust job name to prevent duplicates instead of namespace

### DIFF
--- a/src/main/java/com/hartwig/platinum/kubernetes/KubernetesCluster.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/KubernetesCluster.java
@@ -45,7 +45,8 @@ public class KubernetesCluster {
                     secretVolume.getName(),
                     configMapVolume.getName(),
                     configuration.image());
-            submitted.add(scheduler.submit(new PipelineJob(sample.id(),
+            submitted.add(scheduler.submit(new PipelineJob(runName,
+                    sample.id(),
                     configuration.keystorePassword()
                             .map(p -> new JksEnabledContainer(pipelineContainer.asKubernetes(), maybeJksVolume, p).asKubernetes())
                             .orElse(pipelineContainer.asKubernetes()),

--- a/src/main/java/com/hartwig/platinum/kubernetes/PipelineJob.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/PipelineJob.java
@@ -17,10 +17,10 @@ public class PipelineJob implements KubernetesComponent<JobSpec> {
     private final List<Volume> volumes;
     private final String name;
 
-    public PipelineJob(final String name, final Container container, final List<Volume> volumes) {
+    public PipelineJob(final String run, final String sample, final Container container, final List<Volume> volumes) {
         this.container = container;
         this.volumes = volumes;
-        this.name = name;
+        this.name = sample + "-" + run;
     }
 
     public String getName() {

--- a/src/test/java/com/hartwig/platinum/kubernetes/PipelineJobTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/PipelineJobTest.java
@@ -1,0 +1,18 @@
+package com.hartwig.platinum.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import io.fabric8.kubernetes.api.model.Container;
+
+public class PipelineJobTest {
+
+    @Test
+    public void namesJobWithRunAndSample() {
+        PipelineJob victim = new PipelineJob("run", "sample", new Container(), Collections.emptyList());
+        assertThat(victim.getName()).isEqualTo("sample-run");
+    }
+}


### PR DESCRIPTION
Using different namespaces would complicate secret sharing.