### PR TITLE
DEV-2484 Add ability to specify creation of a node pool

### DIFF
--- a/src/main/java/com/hartwig/platinum/config/GcpConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/GcpConfiguration.java
@@ -21,6 +21,8 @@ public interface GcpConfiguration {
 
     Optional<String> region();
 
+    Optional<NodePoolConfiguration> nodePoolConfiguration();
+
     default String projectOrThrow() {
         return project().orElseThrow(missing("project"));
     }

--- a/src/main/java/com/hartwig/platinum/config/NodePoolConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/NodePoolConfiguration.java
@@ -1,0 +1,13 @@
+package com.hartwig.platinum.config;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableNodePoolConfiguration.class)
+@Value.Style(jdkOnly = true)
+public interface NodePoolConfiguration {
+
+    String name();
+}

--- a/src/main/java/com/hartwig/platinum/config/PlatinumConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/PlatinumConfiguration.java
@@ -60,6 +60,11 @@ public interface PlatinumConfiguration {
 
     List<String> sampleIds();
 
+    @Value.Default
+    default boolean createRun() {
+        return false;
+    }
+
     static ImmutablePlatinumConfiguration.Builder builder() {
         return ImmutablePlatinumConfiguration.builder();
     }

--- a/src/main/java/com/hartwig/platinum/config/SampleConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/SampleConfiguration.java
@@ -15,6 +15,8 @@ public interface SampleConfiguration {
 
     String name();
 
+    List<String> primaryTumorDoids();
+
     List<RawDataConfiguration> tumors();
 
     RawDataConfiguration normal();

--- a/src/main/java/com/hartwig/platinum/kubernetes/GcloudNodePool.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/GcloudNodePool.java
@@ -1,0 +1,37 @@
+package com.hartwig.platinum.kubernetes;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GcloudNodePool {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcloudNodePool.class);
+
+    private final ProcessRunner processRunner;
+
+    public GcloudNodePool(final ProcessRunner processRunner) {
+        this.processRunner = processRunner;
+    }
+
+    void create(final TargetNodePool targetNodePool, final String serviceAccount, final String clusterName, final String project) {
+        LOGGER.info("Creating new node pool with name [{}] machine type [{}] and [{}] nodes",
+                targetNodePool.name(),
+                targetNodePool.machineType(),
+                targetNodePool.numNodes());
+        processRunner.execute(List.of("gcloud",
+                "container",
+                "node-pools",
+                "create",
+                targetNodePool.name(),
+                "--cluster=" + clusterName,
+                "--machine-type=" + targetNodePool.machineType(),
+                "--node-labels=pool=" + targetNodePool.name(),
+                "--node-taints=reserved-pool=true:NoSchedule",
+                "--num-nodes=" + targetNodePool.numNodes(),
+                "--region=europe-west4",
+                "--project=" + project,
+                "--service-account=" + serviceAccount));
+    }
+}

--- a/src/main/java/com/hartwig/platinum/kubernetes/PipelineContainer.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/PipelineContainer.java
@@ -3,8 +3,11 @@ package com.hartwig.platinum.kubernetes;
 import static java.lang.String.format;
 
 import java.util.List;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 
 public class PipelineContainer implements KubernetesComponent<Container> {
@@ -37,6 +40,11 @@ public class PipelineContainer implements KubernetesComponent<Container> {
         container.setCommand(command);
         container.setVolumeMounts(List.of(new VolumeMountBuilder().withMountPath(SAMPLES_PATH).withName(configMapName).build(),
                 new VolumeMountBuilder().withMountPath(SECRETS_PATH).withName(serviceAccountKeySecretName).build()));
+        final ResourceRequirements resourceRequirements = new ResourceRequirements();
+        final Map<String, Quantity> resources = Map.of("cpu", new Quantity("100m"), "memory", new Quantity("256Mi"));
+        resourceRequirements.setLimits(resources);
+        resourceRequirements.setRequests(resources);
+        container.setResources(resourceRequirements);
         return container;
     }
 }

--- a/src/main/java/com/hartwig/platinum/kubernetes/PipelineJob.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/PipelineJob.java
@@ -1,11 +1,15 @@
 package com.hartwig.platinum.kubernetes;
 
 import java.util.List;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecFluent;
+import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.batch.JobSpec;
 import io.fabric8.kubernetes.api.model.batch.JobSpecBuilder;
+import io.fabric8.kubernetes.api.model.batch.JobSpecFluent;
 
 public class PipelineJob implements KubernetesComponent<JobSpec> {
 
@@ -16,10 +20,13 @@ public class PipelineJob implements KubernetesComponent<JobSpec> {
     private final Container container;
     private final List<Volume> volumes;
     private final String name;
+    private final TargetNodePool nodePool;
 
-    public PipelineJob(final String run, final String sample, final Container container, final List<Volume> volumes) {
+    public PipelineJob(final String run, final String sample, final Container container, final List<Volume> volumes,
+            final TargetNodePool nodePool) {
         this.container = container;
         this.volumes = volumes;
+        this.nodePool = nodePool;
         this.name = sample + "-" + run;
     }
 
@@ -34,14 +41,13 @@ public class PipelineJob implements KubernetesComponent<JobSpec> {
     @Override
     public JobSpec asKubernetes() {
         JobSpecBuilder jobSpecBuilder = new JobSpecBuilder();
-        JobSpec spec = jobSpecBuilder.withNewTemplate()
-                .withNewSpec()
-                .withContainers(container)
-                .withRestartPolicy("Never")
-                .withVolumes(volumes)
-                .endSpec()
-                .endTemplate()
-                .build();
+        final PodTemplateSpecFluent.SpecNested<JobSpecFluent.TemplateNested<JobSpecBuilder>> dsl =
+                jobSpecBuilder.withNewTemplate().withNewSpec().withContainers(container).withRestartPolicy("Never").withVolumes(volumes);
+        if (!nodePool.isDefault()) {
+            dsl.withNodeSelector(Map.of("pool", nodePool.name()))
+                    .withTolerations(List.of(new Toleration("NoSchedule", "reserved-pool", "Equal", null, "true")));
+        }
+        JobSpec spec = dsl.endSpec().endTemplate().build();
         spec.setAdditionalProperty("backoffLimit", 1);
         return spec;
     }

--- a/src/main/java/com/hartwig/platinum/kubernetes/TargetNodePool.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/TargetNodePool.java
@@ -1,0 +1,63 @@
+package com.hartwig.platinum.kubernetes;
+
+import com.hartwig.platinum.config.NodePoolConfiguration;
+import com.hartwig.platinum.config.SampleConfiguration;
+
+public interface TargetNodePool {
+
+    boolean isDefault();
+
+    String name();
+
+    String machineType();
+
+    int numNodes();
+
+    static TargetNodePool fromConfig(final NodePoolConfiguration configuration, final int samples) {
+        return new TargetNodePool() {
+            @Override
+            public boolean isDefault() {
+                return false;
+            }
+
+            @Override
+            public String name() {
+                return configuration.name();
+            }
+
+            @Override
+            public String machineType() {
+                return "e2-medium";
+            }
+
+            @Override
+            public int numNodes() {
+                return Math.max(1, samples / 10);
+            }
+        };
+    }
+
+    static TargetNodePool defaultPool() {
+        return new TargetNodePool() {
+            @Override
+            public boolean isDefault() {
+                return true;
+            }
+
+            @Override
+            public String name() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String machineType() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int numNodes() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/src/main/java/com/hartwig/platinum/p5sample/DecomposeSamples.java
+++ b/src/main/java/com/hartwig/platinum/p5sample/DecomposeSamples.java
@@ -29,7 +29,11 @@ public class DecomposeSamples {
                 if (tumor.bam().isPresent()) {
                     pairs.add(ImmutableTumorNormalPair.builder()
                             .reference(ImmutableSample.builder().name(sample.normal().name()).bam(sample.normal().bam()).build())
-                            .tumor(ImmutableSample.builder().name(tumor.name()).bam(tumor.bam()).build())
+                            .tumor(ImmutableSample.builder()
+                                    .name(tumor.name())
+                                    .bam(tumor.bam())
+                                    .primaryTumorDoids(sample.primaryTumorDoids())
+                                    .build())
                             .tumorIndex(indexTumors ? Optional.of(tumorIndexString(tumorIndex)) : Optional.empty())
                             .name(indexTumors ? sample.name() + "-" + tumorIndexString(tumorIndex) : sample.name())
                             .build());
@@ -39,7 +43,11 @@ public class DecomposeSamples {
                                     .name(sample.normal().name())
                                     .lanes(toLanes(sample.normal().fastq()))
                                     .build())
-                            .tumor(ImmutableSample.builder().name(tumor.name()).lanes(toLanes(tumor.fastq())).build())
+                            .tumor(ImmutableSample.builder()
+                                    .name(tumor.name())
+                                    .lanes(toLanes(tumor.fastq()))
+                                    .primaryTumorDoids(sample.primaryTumorDoids())
+                                    .build())
                             .tumorIndex(indexTumors ? Optional.of(tumorIndexString(tumorIndex)) : Optional.empty())
                             .name(indexTumors ? sample.name() + "-" + tumorIndexString(tumorIndex) : sample.name())
                             .build());

--- a/src/main/java/com/hartwig/platinum/p5sample/Sample.java
+++ b/src/main/java/com/hartwig/platinum/p5sample/Sample.java
@@ -18,6 +18,8 @@ public interface Sample {
 
     List<Lane> lanes();
 
+    List<String> primaryTumorDoids();
+
     static ImmutableSample.Builder builder(final String name) {
         return ImmutableSample.builder().name(name);
     }

--- a/src/test/java/com/hartwig/platinum/kubernetes/KubernetesClusterTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/KubernetesClusterTest.java
@@ -54,7 +54,8 @@ public class KubernetesClusterTest {
                 "output",
                 "sa@gcloud.com",
                 PlatinumConfiguration.builder().keystorePassword("changeit").gcp(GCP).build(),
-                delay);
+                delay,
+                TargetNodePool.defaultPool());
         victim.submit(List.of(sample("sample")));
         verify(scheduler).submit(job.capture());
         PipelineJob result = job.getValue();
@@ -75,7 +76,8 @@ public class KubernetesClusterTest {
                 "output",
                 "sa@gcloud.com",
                 PlatinumConfiguration.builder().gcp(GCP).build(),
-                delay);
+                delay,
+                TargetNodePool.defaultPool());
         victim.submit(SAMPLES);
         verify(scheduler).submit(job.capture());
         PipelineJob result = job.getValue();
@@ -91,7 +93,8 @@ public class KubernetesClusterTest {
                 "output",
                 "sa@gcloud.com",
                 PlatinumConfiguration.builder().gcp(GCP).batch(ImmutableBatchConfiguration.builder().size(2).delay(1).build()).build(),
-                delay);
+                delay,
+                TargetNodePool.defaultPool());
         victim.submit(List.of(sample("1"), sample("2"), sample("3"), sample("4"), sample("5")));
 
         ArgumentCaptor<Integer> delayCaptor = ArgumentCaptor.forClass(Integer.class);

--- a/src/test/java/com/hartwig/platinum/kubernetes/PipelineJobTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/PipelineJobTest.java
@@ -12,7 +12,7 @@ public class PipelineJobTest {
 
     @Test
     public void namesJobWithRunAndSample() {
-        PipelineJob victim = new PipelineJob("run", "sample", new Container(), Collections.emptyList());
+        PipelineJob victim = new PipelineJob("run", "sample", new Container(), Collections.emptyList(), TargetNodePool.defaultPool());
         assertThat(victim.getName()).isEqualTo("sample-run");
     }
 }


### PR DESCRIPTION
When a node pool config is added to the gcp config, create a new node pool of e2-medium nodes.

Set limits on the job for cpu (1/10) and memory (256Mi). Empirically 10 pipelines per node seems
to be the most reliable.