### PR TITLE
DEV-2569 Configure fastq input based on bucket structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <jackson.version>2.10.0</jackson.version>
         <failsafe.version>2.0.1</failsafe.version>
         <junit.version>4.13.1</junit.version>
-        <mockito.version>2.23.4</mockito.version>
+        <mockito.version>4.3.1</mockito.version>
         <assertj-core.version>3.8.0</assertj-core.version>
         <google-api-services-iam.version>v1-rev20200709-1.30.10</google-api-services-iam.version>
         <google-api-services-cloudresourcemanager.version>v1-rev20200720-1.30.10</google-api-services-cloudresourcemanager.version>

--- a/src/main/java/com/hartwig/platinum/Platinum.java
+++ b/src/main/java/com/hartwig/platinum/Platinum.java
@@ -9,6 +9,7 @@ import com.google.api.services.iam.v1.Iam;
 import com.google.cloud.storage.Storage;
 import com.hartwig.platinum.config.GcpConfiguration;
 import com.hartwig.platinum.config.PlatinumConfiguration;
+import com.hartwig.platinum.config.SampleBucket;
 import com.hartwig.platinum.config.Validation;
 import com.hartwig.platinum.iam.JsonKey;
 import com.hartwig.platinum.iam.PipelineServiceAccount;
@@ -53,7 +54,9 @@ public class Platinum {
         String serviceAccountEmail = serviceAccount.findOrCreate();
         ServiceAccountPrivateKey privateKey = ServiceAccountPrivateKey.from(configuration, iam);
         JsonKey jsonKey = privateKey.create(gcpConfiguration.projectOrThrow(), serviceAccountEmail);
-        List<TumorNormalPair> pairs = DecomposeSamples.apply(configuration.samples());
+        List<TumorNormalPair> pairs = DecomposeSamples.apply(configuration.sampleBucket()
+                .map(b -> new SampleBucket(storage.get(b)).apply())
+                .orElseGet(configuration::samples));
         int submitted = kubernetesEngine.findOrCreate(runName,
                 pairs,
                 jsonKey,

--- a/src/main/java/com/hartwig/platinum/config/PlatinumConfiguration.java
+++ b/src/main/java/com/hartwig/platinum/config/PlatinumConfiguration.java
@@ -60,6 +60,8 @@ public interface PlatinumConfiguration {
 
     List<String> sampleIds();
 
+    Optional<String> sampleBucket();
+
     @Value.Default
     default boolean createRun() {
         return false;
@@ -69,7 +71,7 @@ public interface PlatinumConfiguration {
         return ImmutablePlatinumConfiguration.builder();
     }
 
-    static PlatinumConfiguration from(String inputFile) {
+    static PlatinumConfiguration from(final String inputFile) {
         ObjectMapper objectMapper = inputFile.endsWith("yaml") ? new ObjectMapper(new YAMLFactory()) : new ObjectMapper();
         objectMapper.registerModule(new Jdk8Module());
         try {

--- a/src/main/java/com/hartwig/platinum/config/SampleBucket.java
+++ b/src/main/java/com/hartwig/platinum/config/SampleBucket.java
@@ -1,0 +1,58 @@
+package com.hartwig.platinum.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+
+public class SampleBucket {
+
+    private static final String TUMOR_PATH = "TUMOR";
+    private static final String NORMAL_PATH = "NORMAL";
+    public static final String R1 = "R1";
+    public static final String R2 = "R2";
+    private final Bucket bucket;
+
+    public SampleBucket(final Bucket bucket) {
+        this.bucket = bucket;
+    }
+
+    public List<SampleConfiguration> apply() {
+        return StreamSupport.stream(bucket.list(Storage.BlobListOption.currentDirectory()).iterateAll().spliterator(), false)
+                .map(blob -> ImmutableSampleConfiguration.builder()
+                        .addTumors(extractFastq(blob, TUMOR_PATH))
+                        .normal(extractFastq(blob, NORMAL_PATH))
+                        .name(blob.getName().replace("/", ""))
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private RawDataConfiguration extractFastq(final Blob blob, final String typePrefix) {
+        final String sampleName =
+                StreamSupport.stream(bucket.list(Storage.BlobListOption.prefix(blob.getName() + typePrefix)).iterateAll().spliterator(),
+                        false).findFirst().map(BlobInfo::getName).map(s -> s.split("/")).map(s -> s[2]).orElseThrow();
+        final Iterable<Blob> fastqs = bucket.list(Storage.BlobListOption.prefix(blob.getName() + typePrefix)).iterateAll();
+        ImmutableRawDataConfiguration.Builder rawDataConfigurationBuilder = ImmutableRawDataConfiguration.builder();
+        for (Blob fastq : fastqs) {
+            if (fastq.getName().contains(R1)) {
+                for (Blob pairCandidate : fastqs) {
+                    if (isMatchingR2(fastq, pairCandidate)) {
+                        rawDataConfigurationBuilder.addFastq(ImmutableFastqConfiguration.builder()
+                                .read1(bucket.getName() + "/" + fastq.getName())
+                                .read2(bucket.getName() + "/" + pairCandidate.getName())
+                                .build());
+                    }
+                }
+            }
+        }
+        return rawDataConfigurationBuilder.name(sampleName).build();
+    }
+
+    private boolean isMatchingR2(final Blob fastq, final Blob pairCandidate) {
+        return pairCandidate.getName().contains(R2) && pairCandidate.getName().replace(R2, "").equals(fastq.getName().replace(R1, ""));
+    }
+}

--- a/src/main/java/com/hartwig/platinum/config/SampleBucket.java
+++ b/src/main/java/com/hartwig/platinum/config/SampleBucket.java
@@ -13,8 +13,8 @@ public class SampleBucket {
 
     private static final String TUMOR_PATH = "TUMOR";
     private static final String NORMAL_PATH = "NORMAL";
-    public static final String R1 = "R1";
-    public static final String R2 = "R2";
+    public static final String R1 = "_R1";
+    public static final String R2 = "_R2";
     private final Bucket bucket;
 
     public SampleBucket(final Bucket bucket) {

--- a/src/test/java/com/hartwig/platinum/config/SampleBucketTest.java
+++ b/src/test/java/com/hartwig/platinum/config/SampleBucketTest.java
@@ -1,0 +1,82 @@
+package com.hartwig.platinum.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public class SampleBucketTest {
+
+    @Test
+    public void emptyBucketReturnsEmptySamples() {
+        Bucket bucket = mock(Bucket.class);
+        Page<Blob> page = mock(Page.class);
+        when(page.iterateAll()).thenReturn(Collections.emptyList());
+        when(bucket.list(Storage.BlobListOption.currentDirectory())).thenReturn(page);
+        SampleBucket victim = new SampleBucket(bucket);
+        assertThat(victim.apply()).isEmpty();
+    }
+
+    @Test
+    public void createsSampleConfigurationFromBucketPath() {
+        Bucket bucket = mock(Bucket.class);
+        Page<Blob> samplePage = mock(Page.class);
+        Blob setDirectory = blob("COLO829/");
+        when(samplePage.iterateAll()).thenReturn(List.of(setDirectory));
+        when(bucket.list(Storage.BlobListOption.currentDirectory())).thenReturn(samplePage);
+
+        Blob normalDirectory = blob("COLO829/NORMAL/COLO829R");
+        Page<Blob> normalDirectoryPage = mock(Page.class);
+        when(normalDirectoryPage.iterateAll()).thenReturn(List.of(normalDirectory));
+        when(bucket.list(Storage.BlobListOption.prefix("COLO829/NORMAL"), Storage.BlobListOption.currentDirectory())).thenReturn(
+                normalDirectoryPage);
+
+        Blob normalFastqR1 = blob("COLO829/NORMAL/COLO829R/COLO829R_R1_001.fastq.gz");
+        Blob normalFastqR2 = blob("COLO829/NORMAL/COLO829R/COLO829R_R2_001.fastq.gz");
+        Page<Blob> normalFastqPage = mock(Page.class);
+        when(normalFastqPage.iterateAll()).thenReturn(List.of(normalFastqR1, normalFastqR2));
+        when(bucket.list(Storage.BlobListOption.prefix("COLO829/NORMAL"))).thenReturn(normalFastqPage);
+
+        Blob tumorDirectory = blob("COLO829/NORMAL/COLO829T");
+        Page<Blob> tumorDirectoryPage = mock(Page.class);
+        when(tumorDirectoryPage.iterateAll()).thenReturn(List.of(tumorDirectory));
+        when(bucket.list(Storage.BlobListOption.prefix("COLO829/TUMOR"), Storage.BlobListOption.currentDirectory())).thenReturn(
+                tumorDirectoryPage);
+
+        Blob tumorFastqR1 = blob("COLO829/TUMOR/COLO829T/COLO829T_R1_001.fastq.gz");
+        Blob tumorFastqR2 = blob("COLO829/TUMOR/COLO829T/COLO829T_R2_001.fastq.gz");
+        Page<Blob> tumorFastqPage = mock(Page.class);
+        when(tumorFastqPage.iterateAll()).thenReturn(List.of(tumorFastqR1, tumorFastqR2));
+        when(bucket.list(Storage.BlobListOption.prefix("COLO829/TUMOR"))).thenReturn(tumorFastqPage);
+
+        SampleBucket victim = new SampleBucket(bucket);
+        final List<SampleConfiguration> result = victim.apply();
+        assertThat(result).hasSize(1);
+        SampleConfiguration sampleConfiguration = result.get(0);
+        assertThat(sampleConfiguration.name()).isEqualTo("COLO829");
+        assertThat(sampleConfiguration.normal().name()).isEqualTo("COLO829R");
+        assertThat(sampleConfiguration.tumors().get(0).name()).isEqualTo("COLO829T");
+
+        assertThat(sampleConfiguration.normal().fastq().get(0).read1()).isEqualTo("COLO829/NORMAL/COLO829R/COLO829R_R1_001.fastq.gz");
+        assertThat(sampleConfiguration.normal().fastq().get(0).read2()).isEqualTo("COLO829/NORMAL/COLO829R/COLO829R_R2_001.fastq.gz");
+        assertThat(sampleConfiguration.tumors().get(0).fastq().get(0).read1()).isEqualTo("COLO829/TUMOR/COLO829T/COLO829T_R1_001.fastq.gz");
+        assertThat(sampleConfiguration.tumors().get(0).fastq().get(0).read2()).isEqualTo("COLO829/TUMOR/COLO829T/COLO829T_R2_001.fastq.gz");
+    }
+
+    private Blob blob(final String name) {
+        Blob blob = mock(Blob.class);
+        when(blob.getName()).thenReturn(name);
+        return blob;
+    }
+
+}

--- a/src/test/java/com/hartwig/platinum/config/SampleBucketTest.java
+++ b/src/test/java/com/hartwig/platinum/config/SampleBucketTest.java
@@ -30,6 +30,7 @@ public class SampleBucketTest {
     @Test
     public void createsSampleConfigurationFromBucketPath() {
         Bucket bucket = mock(Bucket.class);
+        when(bucket.getName()).thenReturn("bucket");
         Page<Blob> samplePage = mock(Page.class);
         Blob setDirectory = blob("COLO829/");
         when(samplePage.iterateAll()).thenReturn(List.of(setDirectory));
@@ -67,10 +68,14 @@ public class SampleBucketTest {
         assertThat(sampleConfiguration.normal().name()).isEqualTo("COLO829R");
         assertThat(sampleConfiguration.tumors().get(0).name()).isEqualTo("COLO829T");
 
-        assertThat(sampleConfiguration.normal().fastq().get(0).read1()).isEqualTo("COLO829/NORMAL/COLO829R/COLO829R_R1_001.fastq.gz");
-        assertThat(sampleConfiguration.normal().fastq().get(0).read2()).isEqualTo("COLO829/NORMAL/COLO829R/COLO829R_R2_001.fastq.gz");
-        assertThat(sampleConfiguration.tumors().get(0).fastq().get(0).read1()).isEqualTo("COLO829/TUMOR/COLO829T/COLO829T_R1_001.fastq.gz");
-        assertThat(sampleConfiguration.tumors().get(0).fastq().get(0).read2()).isEqualTo("COLO829/TUMOR/COLO829T/COLO829T_R2_001.fastq.gz");
+        assertThat(sampleConfiguration.normal().fastq().get(0).read1()).isEqualTo("bucket/COLO829/NORMAL/COLO829R/COLO829R_R1_001.fastq"
+                + ".gz");
+        assertThat(sampleConfiguration.normal().fastq().get(0).read2()).isEqualTo("bucket/COLO829/NORMAL/COLO829R/COLO829R_R2_001.fastq"
+                + ".gz");
+        assertThat(sampleConfiguration.tumors().get(0).fastq().get(0).read1()).isEqualTo("bucket/COLO829/TUMOR/COLO829T/COLO829T_R1_001"
+                + ".fastq.gz");
+        assertThat(sampleConfiguration.tumors().get(0).fastq().get(0).read2()).isEqualTo("bucket/COLO829/TUMOR/COLO829T/COLO829T_R2_001"
+                + ".fastq.gz");
     }
 
     private Blob blob(final String name) {


### PR DESCRIPTION
Creates a sample list from a GCS path:

/SAMPLE/{TUMOR|NORMAL}/{TUMOR_NAME|NORMALNAME}/*.fastq.gz

The fastq must be paired end, with each pair identical except for R1/R2.