### PR TITLE
DEV-2956 Make new runs with is_hidden set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <google-api-services-iam.version>v1-rev20200709-1.30.10</google-api-services-iam.version>
         <google-api-services-cloudresourcemanager.version>v1-rev20200720-1.30.10</google-api-services-cloudresourcemanager.version>
         <google-api-services-container.version>v1beta1-rev20200724-1.30.10</google-api-services-container.version>
-        <java-client.version>local-SNAPSHOT</java-client.version>
+        <java-client.version>1.26.0</java-client.version>
     </properties>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <google-api-services-iam.version>v1-rev20200709-1.30.10</google-api-services-iam.version>
         <google-api-services-cloudresourcemanager.version>v1-rev20200720-1.30.10</google-api-services-cloudresourcemanager.version>
         <google-api-services-container.version>v1beta1-rev20200724-1.30.10</google-api-services-container.version>
-        <java-client.version>1.14.1</java-client.version>
+        <java-client.version>local-SNAPSHOT</java-client.version>
     </properties>
 
     <distributionManagement>

--- a/src/main/java/com/hartwig/platinum/ApiRerun.java
+++ b/src/main/java/com/hartwig/platinum/ApiRerun.java
@@ -3,7 +3,6 @@ package com.hartwig.platinum;
 import java.util.List;
 import java.util.Optional;
 
-import com.hartwig.ApiException;
 import com.hartwig.api.RunApi;
 import com.hartwig.api.SampleApi;
 import com.hartwig.api.SetApi;
@@ -58,6 +57,7 @@ public class ApiRerun {
                                     .ini(Ini.RERUN_INI)
                                     .version(version)
                                     .status(Status.PENDING)
+                                    .isHidden(true)
                                     .setId(sampleSet.getId())).getId();
                             LOGGER.info("Created API run for sample [{}] id [{}]", sampleId, id);
                             return id;

--- a/src/main/java/com/hartwig/platinum/PlatinumMain.java
+++ b/src/main/java/com/hartwig/platinum/PlatinumMain.java
@@ -57,7 +57,7 @@ public class PlatinumMain implements Callable<Integer> {
                             api.sets(),
                             api.samples(),
                             configuration.outputBucket().get(),
-                            configuration.image().split(":")[1])).run();
+                            (configuration.image().split(":")[1]).split("-")[0])).run();
             return 0;
         } catch (Exception e) {
             LOGGER.error("Unexpected exception", e);

--- a/src/test/java/com/hartwig/platinum/ApiRerunTest.java
+++ b/src/test/java/com/hartwig/platinum/ApiRerunTest.java
@@ -1,0 +1,111 @@
+package com.hartwig.platinum;
+
+import static java.util.Collections.emptyList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import com.hartwig.api.RunApi;
+import com.hartwig.api.SampleApi;
+import com.hartwig.api.SetApi;
+import com.hartwig.api.model.CreateRun;
+import com.hartwig.api.model.Ini;
+import com.hartwig.api.model.Run;
+import com.hartwig.api.model.RunCreated;
+import com.hartwig.api.model.Sample;
+import com.hartwig.api.model.SampleSet;
+import com.hartwig.api.model.SampleType;
+import com.hartwig.api.model.Status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class ApiRerunTest {
+    private RunApi runs;
+    private SetApi sets;
+    private SampleApi sampleApi;
+    private String bucket = "bucket";
+    private String version = "notarealversion";
+    private String biopsy = "sample";
+    private Long sampleId = 1L;
+    private Long sampleSetId = 2L;
+    private Run validatedRun = new Run().status(Status.VALIDATED);
+    private Run existingReRun = new Run().status(Status.PENDING).id(3L);
+    private List<Sample> samples;
+    private SampleSet sampleSet;
+
+    @Before
+    public void setup() {
+        runs = mock(RunApi.class);
+        sets = mock(SetApi.class);
+        sampleApi = mock(SampleApi.class);
+
+        samples = List.of(new Sample().name(biopsy).id(sampleId));
+        sampleSet = new SampleSet().id(sampleSetId);
+
+        when(sampleApi.list(null, null, null, null, SampleType.TUMOR, biopsy)).thenReturn(samples);
+        when(runs.list(null, null, sampleSet.getId(), null, null, null, null, null))
+                .thenReturn(List.of(validatedRun));
+    }
+
+    @Test
+    public void shouldReturnIdOfExistingRunIfItIsNotInvalidated() {
+        when(sets.list(null, samples.get(0).getId(), true)).thenReturn(List.of(sampleSet));
+        when(runs.list(null, Ini.RERUN_INI, sampleSet.getId(), version, version, null, null, null))
+                .thenReturn(List.of(existingReRun));
+
+        assertThat(new ApiRerun(runs, sets, sampleApi, bucket, version).create(biopsy)).isEqualTo(3L);
+        verify(runs, never()).create(any());
+    }
+
+    @Test
+    public void shouldReturnNullAndCreateNoRunsIfNoSamplesMatchGivenId() {
+        when(sampleApi.list(null, null, null, null, SampleType.TUMOR, biopsy)).thenReturn(emptyList());
+        assertThat(new ApiRerun(runs, sets, sampleApi, bucket, version).create(biopsy)).isNull();
+        verify(runs, never()).create(any());
+    }
+
+    @Test
+    public void shouldReturnNullAndCreateNoRunsIfNoSampleSetExistsForSample() {
+        when(sets.list(null, samples.get(0).getId(), true)).thenReturn(null);
+        assertThat(new ApiRerun(runs, sets, sampleApi, bucket, version).create(biopsy)).isNull();
+        verify(runs, never()).create(any());
+    }
+
+    @Test
+    public void shouldReturnNullAndCreateNoRunsIfNoValidatedRunExistsForSample() {
+        when(sets.list(null, samples.get(0).getId(), true)).thenReturn(List.of(sampleSet));
+        when(runs.list(null, null, sampleSet.getId(), null, null, null, null, null))
+                .thenReturn(emptyList());
+        assertThat(new ApiRerun(runs, sets, sampleApi, bucket, version).create(biopsy)).isNull();
+        verify(runs, never()).create(any());
+    }
+
+    @Test
+    public void shouldCreateRunForSampleIfNoneExists() {
+        when(runs.list(null, Ini.RERUN_INI, sampleSet.getId(), version, version, null, null, null))
+                .thenReturn(emptyList());
+        when(sets.list(null, samples.get(0).getId(), true)).thenReturn(List.of(sampleSet));
+        ArgumentCaptor<CreateRun> createRunCaptor = ArgumentCaptor.forClass(CreateRun.class);
+        when(runs.create(createRunCaptor.capture())).thenReturn(new RunCreated().id(3L));
+
+        assertThat(new ApiRerun(runs, sets, sampleApi, bucket, version).create(biopsy)).isNotNull();
+        CreateRun createRun = createRunCaptor.getValue();
+        assertThat(createRun).isNotNull();
+        assertThat(createRun.getCluster()).isEqualTo("gcp");
+        assertThat(createRun.getBucket()).isEqualTo(bucket);
+        assertThat(createRun.getIni()).isEqualTo(Ini.RERUN_INI);
+        assertThat(createRun.getSetId()).isEqualTo(sampleSetId);
+        assertThat(createRun.getVersion()).isEqualTo(version);
+        assertThat(createRun.getContext()).isEqualTo("RESEARCH");
+        assertThat(createRun.getStatus()).isEqualTo(Status.PENDING);
+        assertThat(createRun.getIsHidden()).isEqualTo(true);
+    }
+}


### PR DESCRIPTION
We want reruns to be hidden from the datasets until we have validated them.

Also we want the version that is set on the reruns to be just the numeric portion, without the "-rerun..." suffix we started using in 5.30.

Finally add some tests for the ApiRerun.