### PR TITLE
DEV-2987 Halt when node pool cannot be created

### DIFF
--- a/src/main/java/com/hartwig/platinum/kubernetes/GcloudNodePool.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/GcloudNodePool.java
@@ -1,5 +1,7 @@
 package com.hartwig.platinum.kubernetes;
 
+import static java.lang.String.format;
+
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -20,7 +22,7 @@ public class GcloudNodePool {
                 targetNodePool.name(),
                 targetNodePool.machineType(),
                 targetNodePool.numNodes());
-        processRunner.execute(List.of("gcloud",
+        List<String> arguments = List.of("gcloud",
                 "container",
                 "node-pools",
                 "create",
@@ -32,6 +34,9 @@ public class GcloudNodePool {
                 "--num-nodes=" + targetNodePool.numNodes(),
                 "--region=europe-west4",
                 "--project=" + project,
-                "--service-account=" + serviceAccount));
+                "--service-account=" + serviceAccount);
+        if (!processRunner.execute(arguments)) {
+            throw new RuntimeException(format("Failed to create node pool via command: [%s]", String.join(" ", arguments)));
+        }
     }
 }


### PR DESCRIPTION
I noticed this behaviour during the 5.30 rerun and it causes confusion since even if there is a node pool already existing in the cluster, if it wasn't created by Platinum it won't have the required "pool=" label that will allow the created jobs to be run on its nodes.