### PR TITLE
DEV-3228 Improve handling of multi-set samples

### DIFF
--- a/src/main/java/com/hartwig/platinum/ApiRerun.java
+++ b/src/main/java/com/hartwig/platinum/ApiRerun.java
@@ -1,5 +1,11 @@
 package com.hartwig.platinum;
 
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.hartwig.api.RunApi;
 import com.hartwig.api.SampleApi;
 import com.hartwig.api.SetApi;
@@ -33,12 +39,36 @@ public class ApiRerun {
     }
 
     public long create(final String tumorSampleName) {
-        return sampleApi.list(null, null, null, null, SampleType.TUMOR, tumorSampleName, null)
-                .stream()
-                .findFirst()
-                .flatMap(sample -> OnlyOne.ofNullable(setApi.list(null, sample.getId(), true), SampleSet.class))
-                .map(sampleSet -> getOrCreateRun(tumorSampleName, sampleSet))
-                .orElseThrow(() -> illegalArgumentException(tumorSampleName, "No sets with consent for database could be found."));
+        List<SampleSet> sets = setApi.list(null,
+                sampleApi.list(null, null, null, null, SampleType.TUMOR, tumorSampleName, null)
+                        .stream()
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException(format("Cannot find tumor sample [%s]", tumorSampleName)))
+                        .getId(),
+                true);
+        if (sets.isEmpty()) {
+            throw new IllegalArgumentException(format("No sets with consent for the database could be found for [%s]", tumorSampleName));
+        }
+        return getOrCreateRun(tumorSampleName, sets.size() == 1 ? sets.get(0) : resolveActiveSet(sets, tumorSampleName));
+    }
+
+    private SampleSet resolveActiveSet(List<SampleSet> sets, String tumorSampleName) {
+        List<SampleSet> setsWithNonInvalidatedRuns = new ArrayList<>();
+        for (SampleSet set : sets) {
+            List<Run> runs = runApi.list(null, null, set.getId(), null, null, null, null, null);
+            if (runs.stream().anyMatch(r -> r.getStatus() != Status.INVALIDATED)) {
+                setsWithNonInvalidatedRuns.add(set);
+            }
+        }
+        if (setsWithNonInvalidatedRuns.isEmpty()) {
+            throw new IllegalStateException(format("Multiple sets found for tumor sample [%s] but none have non-invalidated runs attached",
+                    tumorSampleName));
+        } else if (setsWithNonInvalidatedRuns.size() > 1) {
+            throw new IllegalStateException(format("Multiple sets with non-invalidated runs found for tumor sample [%s]: %s",
+                    tumorSampleName,
+                    setsWithNonInvalidatedRuns.stream().map(s -> s.getId().toString()).collect(Collectors.joining(","))));
+        }
+        return setsWithNonInvalidatedRuns.get(0);
     }
 
     /**
@@ -63,9 +93,5 @@ public class ApiRerun {
                     LOGGER.info("Created API run for sample [{}] id [{}]", tumorSampleName, id);
                     return id;
                 });
-    }
-
-    private static IllegalArgumentException illegalArgumentException(final String tumorSampleName, String message) {
-        return new IllegalArgumentException(String.format("Tumor sample [%s] could not be rerun. %s", tumorSampleName, message));
     }
 }


### PR DESCRIPTION
Prior to this change if we ever discovered multiple sets for the same sample we would be unable to continue. However this situation does occur when a new reference sample is provided and the tumor sample re-used.

Use the status of the attached runs when this situation is encountered to try to resolve the correct set.