### PR TITLE
DEV-3254 Use setId and context but ignore dbStatus for run selection

### DIFF
--- a/src/main/java/com/hartwig/platinum/pdl/ConvertForBiopsies.java
+++ b/src/main/java/com/hartwig/platinum/pdl/ConvertForBiopsies.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import com.hartwig.api.RunApi;
 import com.hartwig.api.SampleApi;
 import com.hartwig.api.SetApi;
-import com.hartwig.api.model.DbStatus;
 import com.hartwig.api.model.Ini;
 import com.hartwig.api.model.Run;
 import com.hartwig.api.model.SampleType;
@@ -37,7 +36,7 @@ public class ConvertForBiopsies implements PDLConversion {
                 .stream()
                 .flatMap(biopsy -> sampleApi.list(null, null, null, null, SampleType.TUMOR, biopsy, null).stream())
                 .flatMap(sample -> setApi.list(null, sample.getId(), true).stream())
-                .flatMap(set -> runApi.list(null, Ini.SOMATIC_INI, null, null, null, DbStatus.ADDED, null, null)
+                .flatMap(set -> runApi.list(null, Ini.SOMATIC_INI, set.getId(), null, null, null, null, "RESEARCH")
                         .stream()
                         .filter(run -> run.getEndTime() != null)
                         .max(Comparator.comparing(Run::getEndTime))

--- a/src/main/java/com/hartwig/platinum/pdl/ConvertForBiopsies.java
+++ b/src/main/java/com/hartwig/platinum/pdl/ConvertForBiopsies.java
@@ -11,6 +11,7 @@ import com.hartwig.api.SetApi;
 import com.hartwig.api.model.Ini;
 import com.hartwig.api.model.Run;
 import com.hartwig.api.model.SampleType;
+import com.hartwig.api.model.Status;
 import com.hartwig.pdl.ImmutablePipelineInput;
 import com.hartwig.pdl.PipelineInput;
 import com.hartwig.pdl.generator.PdlGenerator;
@@ -36,7 +37,7 @@ public class ConvertForBiopsies implements PDLConversion {
                 .stream()
                 .flatMap(biopsy -> sampleApi.list(null, null, null, null, SampleType.TUMOR, biopsy, null).stream())
                 .flatMap(sample -> setApi.list(null, sample.getId(), true).stream())
-                .flatMap(set -> runApi.list(null, Ini.SOMATIC_INI, set.getId(), null, null, null, null, "RESEARCH")
+                .flatMap(set -> runApi.list(Status.VALIDATED, Ini.SOMATIC_INI, set.getId(), null, null, null, null, "RESEARCH")
                         .stream()
                         .filter(run -> run.getEndTime() != null)
                         .max(Comparator.comparing(Run::getEndTime))


### PR DESCRIPTION
The runApi.list action currently does not make use of the `set` variable in flatMap (while it makes sense to do so by limiting the runs to those from that set). Also I think we should only want runs from `RESEARCH` context (since those have data in datasets) and ignore the `dbStatus` because there are a lot of runs with dbStatus set to `Unknown`.

Not sure if we should limit this runApi.list even further to only include `Validated` runs.