### PR TITLE
DEV-3284 Add memory limits for non-rerun jobs

### DIFF
--- a/src/main/java/com/hartwig/platinum/kubernetes/PipelineContainer.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/PipelineContainer.java
@@ -1,7 +1,6 @@
 package com.hartwig.platinum.kubernetes;
 
-import static java.lang.String.format;
-
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,13 +41,16 @@ public class PipelineContainer implements KubernetesComponent<Container> {
         container.setCommand(command);
         container.setVolumeMounts(List.of(new VolumeMountBuilder().withMountPath(SAMPLES_PATH).withName(configMapName).build(),
                 new VolumeMountBuilder().withMountPath(SECRETS_PATH).withName(serviceAccountKeySecretName).build()));
+        final ResourceRequirements resourceRequirements = new ResourceRequirements();
+        final Map<String, Quantity> resources = new HashMap<>();
         if (configuration.samples().isEmpty() && configuration.sampleBucket().isEmpty()) {
-            final ResourceRequirements resourceRequirements = new ResourceRequirements();
-            final Map<String, Quantity> resources = Map.of("cpu", new Quantity("100m"), "memory", new Quantity("512Mi"));
-            resourceRequirements.setLimits(resources);
-            resourceRequirements.setRequests(resources);
-            container.setResources(resourceRequirements);
+            resources.putAll(Map.of("cpu", new Quantity("100m"), "memory", new Quantity("512Mi")));
+        } else {
+            resources.put("memory", new Quantity("1024Mi"));
         }
+        resourceRequirements.setLimits(resources);
+        resourceRequirements.setRequests(resources);
+        container.setResources(resourceRequirements);
         return container;
     }
 }


### PR DESCRIPTION
Without any resource limits the autoscaler doesn't kick in and the nodes get overwhelmed. Add memory-only limits (so a lack of CPU doesn't affect download speed for the FASTQ files) for non-rerun jobs. We can refine as necessary.