### PR TITLE
DEV-3337 Fix auth loop

### DIFF
--- a/src/main/java/com/hartwig/platinum/kubernetes/JobSubmitter.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/JobSubmitter.java
@@ -47,7 +47,7 @@ public class JobSubmitter {
         try {
             kubernetesClientProxy.jobs()
                     .create(new JobBuilder().withNewMetadata()
-                            .withName(job.getName())
+                            .withName(KubernetesUtil.toValidRFC1123Label(job.getName()))
                             .withNamespace(NAMESPACE)
                             .endMetadata()
                             .withSpec(spec)

--- a/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineConfigMapVolume.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineConfigMapVolume.java
@@ -2,6 +2,8 @@ package com.hartwig.platinum.kubernetes.pipeline;
 
 import static java.lang.String.format;
 
+import static com.hartwig.platinum.kubernetes.KubernetesUtil.toValidRFC1123Label;
+
 import java.util.Map;
 
 import com.hartwig.platinum.kubernetes.KubernetesClientProxy;
@@ -21,7 +23,7 @@ public class PipelineConfigMapVolume implements KubernetesComponent<Volume> {
 
     private PipelineConfigMapVolume(final KubernetesClientProxy kubernetesClientProxy, final String runName, final String sample, final String content) {
         this.kubernetesClientProxy = kubernetesClientProxy;
-        this.volumeName = format("%s-%s", runName, sample);
+        this.volumeName = toValidRFC1123Label(format("%s-%s", runName, sample));
         this.sample = sample;
         this.content = content;
     }

--- a/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineContainer.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineContainer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import com.hartwig.platinum.config.PlatinumConfiguration;
 import com.hartwig.platinum.kubernetes.KubernetesComponent;
+import com.hartwig.platinum.kubernetes.KubernetesUtil;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -37,7 +38,7 @@ public class PipelineContainer implements KubernetesComponent<Container> {
     public Container asKubernetes() {
         Container container = new Container();
         container.setImage(imageName);
-        container.setName(sample.id());
+        container.setName(KubernetesUtil.toValidRFC1123Label(sample.id()));
         List<String> command = arguments.asCommand(sample, SECRETS_PATH, serviceAccountKeySecretName);
         container.setCommand(command);
         container.setVolumeMounts(List.of(new VolumeMountBuilder().withMountPath(SAMPLES_PATH).withName(configMapName).build(),


### PR DESCRIPTION
Platinum would sit forever claiming it was "Authorising with cluster" but never getting past that.

The cause was incorrect configuration being pushed which was causing a KubernetesClientException, which itself was tricking the code into thinking it needed to re-authorise.

I modified the code to sanitise the names of a few entries that had recently changed and which weren't being converted to the DNS-compliant names Kubernetes requires.

Test cases should also be written to address this. For the moment just pushing implementation updates so others aren't blocked.