### PR TITLE
DEV-3378 Fix handling of existing jobs

### DIFF
--- a/src/main/java/com/hartwig/platinum/kubernetes/JobSubmitter.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/JobSubmitter.java
@@ -47,7 +47,7 @@ public class JobSubmitter {
         try {
             kubernetesClientProxy.jobs()
                     .create(new JobBuilder().withNewMetadata()
-                            .withName(KubernetesUtil.toValidRFC1123Label(job.getName()))
+                            .withName(job.getName())
                             .withNamespace(NAMESPACE)
                             .endMetadata()
                             .withSpec(spec)

--- a/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineJob.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineJob.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.hartwig.platinum.kubernetes.KubernetesComponent;
+import com.hartwig.platinum.kubernetes.KubernetesUtil;
 import com.hartwig.platinum.kubernetes.TargetNodePool;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -33,7 +34,7 @@ public class PipelineJob implements KubernetesComponent<JobSpec> {
         this.volumes = volumes;
         this.nodePool = nodePool;
         this.ttl = ttl;
-        this.name = name;
+        this.name = KubernetesUtil.toValidRFC1123Label(name);
     }
 
     public String getName() {


### PR DESCRIPTION
We've got another situation like the recent "auth loop" that was previously reported. This one is happening when a job already exists, as when the batch was already executed once and now the user is trying again.

Similar fix, this was just a bug in when the job name was being converted to Kubernetes-compatible format.