### PR TITLE
DEV-3465 Correct job submission logic

### DIFF
--- a/src/main/java/com/hartwig/platinum/scheduling/ConstantJobCountScheduler.java
+++ b/src/main/java/com/hartwig/platinum/scheduling/ConstantJobCountScheduler.java
@@ -1,19 +1,17 @@
 package com.hartwig.platinum.scheduling;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.hartwig.platinum.kubernetes.JobSubmitter;
 import com.hartwig.platinum.kubernetes.KubernetesClientProxy;
 import com.hartwig.platinum.kubernetes.pipeline.PipelineJob;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.fabric8.kubernetes.api.model.batch.Job;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ConstantJobCountScheduler implements JobScheduler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConstantJobCountScheduler.class);
@@ -56,7 +54,7 @@ public class ConstantJobCountScheduler implements JobScheduler {
     }
 
     private boolean jobIs(Job job, JobState state) {
-        return job.getStatus().getConditions().stream().anyMatch(c -> state.name().equalsIgnoreCase(c.getType()) && "True".equals(c.getStatus()));
+        return JobSubmitter.jobIs(job, state.name());
     }
 
     private List<PipelineJob> waitForCapacity() {

--- a/src/test/java/com/hartwig/platinum/kubernetes/JobSubmitterTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/JobSubmitterTest.java
@@ -1,0 +1,92 @@
+package com.hartwig.platinum.kubernetes;
+
+import com.hartwig.platinum.kubernetes.pipeline.PipelineJob;
+import io.fabric8.kubernetes.api.model.batch.*;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.hartwig.platinum.kubernetes.KubernetesCluster.NAMESPACE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class JobSubmitterTest {
+    private static final String JOB_NAME = "job1";
+    @SuppressWarnings("rawtypes")
+    private final NonNamespaceOperation jobs = mock(NonNamespaceOperation.class);
+    @SuppressWarnings("unchecked")
+    private final ScalableResource<Job> scalableJob = mock(ScalableResource.class);
+    private final PipelineJob pipelineJob = mock(PipelineJob.class);
+    private final JobSpec jobSpec = mock(JobSpec.class);
+    private JobSubmitter victim;
+    private KubernetesClientProxy kubernetesClientProxy;
+    private Job job;
+
+    @Before
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        kubernetesClientProxy = mock(KubernetesClientProxy.class);
+        victim = new JobSubmitter(kubernetesClientProxy, false);
+
+        when(pipelineJob.getName()).thenReturn(JOB_NAME);
+        when(pipelineJob.asKubernetes()).thenReturn(jobSpec);
+        when(kubernetesClientProxy.jobs()).thenReturn(jobs);
+        when(jobs.withName(JOB_NAME)).thenReturn(scalableJob);
+
+        job = new JobBuilder().withNewMetadata().withName(JOB_NAME).withNamespace(NAMESPACE).endMetadata().withSpec(jobSpec).build();
+    }
+
+    @Test
+    public void shouldSubmitNewJobIfNamedJobDoesNotExist() {
+        verifyWhetherJobCreatedAndReturnValueIs(true, true);
+    }
+
+    @Test
+    public void shouldNotSubmitAnythingIfJobCompletedAlready() {
+        setupJobConditions(Map.of("Complete", "True", "OtherState", "True"));
+        verifyWhetherJobCreatedAndReturnValueIs(false, false);
+    }
+
+    @Test
+    public void shouldNotSubmitAnythingIfJobFailedAndRetryIsFalse() {
+        setupJobConditions(Map.of("Failed", "True", "Complete", "False"));
+        verifyWhetherJobCreatedAndReturnValueIs(false, false);
+    }
+
+    @Test
+    public void shouldResubmitFailedJobIfRetryIsTrue() {
+        victim = new JobSubmitter(kubernetesClientProxy, true);
+        setupJobConditions(Map.of("Failed", "True", "Running", "False"));
+        verifyWhetherJobCreatedAndReturnValueIs(true, true);
+    }
+
+    @Test
+    public void shouldNotResubmitRunningJobButShouldTellSchedulerItDidSubmitIt() {
+        setupJobConditions(Map.of("Complete", "False"));
+        verifyWhetherJobCreatedAndReturnValueIs(false, true);
+    }
+
+    private void setupJobConditions(Map<String, String> statuses) {
+        Job existingJob = mock(Job.class);
+        JobStatus jobStatus = mock(JobStatus.class);
+        when(existingJob.getStatus()).thenReturn(jobStatus);
+        when(jobStatus.getConditions()).thenReturn(statuses.keySet().stream().map(status ->
+                new JobCondition(null, null, null, null, statuses.get(status), status)
+        ).collect(Collectors.toList()));
+        when(scalableJob.get()).thenReturn(existingJob);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void verifyWhetherJobCreatedAndReturnValueIs(boolean jobCreated, boolean returnValue) {
+        assertThat(victim.submit(pipelineJob)).isEqualTo(returnValue);
+        if (jobCreated) {
+            verify(jobs).create(job);
+        } else {
+            verify(jobs, never()).create(any());
+        }
+    }
+}


### PR DESCRIPTION
Use the conditions on the Job rather than the dodgy logic similar to what was recently corrected in the `ConstantJobCountScheduler`. The code from that class has been altered to delegate to the `jobIs` method in ``JobSubmitter`.

This should fix some misbehaviour around what to do with existing jobs. Before this change, Platinum would ignore running jobs (so it would lose track of them essentially), which can happen anytime Platinum gets killed. This does happen often enough during reruns.

The new code should detect this situation and adopt any running jobs. It will also therefore not allow more pipelines to be started than were intended from the value of the batch size parameter.

Finally I noticed there was no test for the `JobSubmitter` so added one.