### PR TITLE
DEV-3575 Fix reference-only mode

### DIFF
--- a/src/main/java/com/hartwig/platinum/kubernetes/KubernetesCluster.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/KubernetesCluster.java
@@ -54,7 +54,11 @@ public class KubernetesCluster {
         for (Supplier<PipelineInput> inputSupplier : pipelineInputs) {
             try {
                 PipelineInput pipelineInput = inputSupplier.get();
-                String sampleName = pipelineInput.tumor().map(SampleInput::name).orElseThrow();
+                String sampleName = pipelineInput.tumor()
+                        .map(SampleInput::name)
+                        .orElseGet(() -> pipelineInput.reference()
+                                .map(SampleInput::name)
+                                .orElseThrow(() -> new IllegalArgumentException("At least one tumor or reference sample must be provided")));
                 SampleArgument sample = SampleArgument.sampleJson(sampleName, runName);
                 Volume configMapVolume = configMaps.forSample(sampleName, pipelineInput);
                 PipelineContainer pipelineContainer = new PipelineContainer(sample,
@@ -76,7 +80,7 @@ public class KubernetesCluster {
                         configuration.gcp().jobTtl().orElse(Duration.ZERO)));
                 numSubmitted++;
             } catch (Exception e) {
-                LOGGER.warn("Unexpected failure, skipping further processing of sample");
+                LOGGER.warn("Unexpected failure, skipping further processing of sample", e);
                 failures++;
             }
         }

--- a/src/main/java/com/hartwig/platinum/kubernetes/KubernetesCluster.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/KubernetesCluster.java
@@ -55,10 +55,9 @@ public class KubernetesCluster {
             try {
                 PipelineInput pipelineInput = inputSupplier.get();
                 String sampleName = pipelineInput.tumor()
+                        .or(pipelineInput::reference)
                         .map(SampleInput::name)
-                        .orElseGet(() -> pipelineInput.reference()
-                                .map(SampleInput::name)
-                                .orElseThrow(() -> new IllegalArgumentException("At least one tumor or reference sample must be provided")));
+                        .orElseThrow(() -> new IllegalArgumentException("At least one tumor or reference sample must be provided"));
                 SampleArgument sample = SampleArgument.sampleJson(sampleName, runName);
                 Volume configMapVolume = configMaps.forSample(sampleName, pipelineInput);
                 PipelineContainer pipelineContainer = new PipelineContainer(sample,

--- a/src/test/java/com/hartwig/platinum/kubernetes/KubernetesClusterTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/KubernetesClusterTest.java
@@ -48,7 +48,7 @@ public class KubernetesClusterTest {
         scheduler = mock(JobScheduler.class);
         configMaps = mock(PipelineConfigMapBuilder.class);
         SampleInput tumor = SampleInput.builder().name("tumor-a").build();
-        PipelineInput input1 = PipelineInput.builder().setName("setName").tumor(tumor)/*.reference(reference)*/.build();
+        PipelineInput input1 = PipelineInput.builder().setName("setName").tumor(tumor).build();
         pipelineInputs = List.of(() -> input1);
         when(configMaps.forSample(any(), any())).thenReturn(new VolumeBuilder().withName(CONFIG).build());
         ServiceAccountConfiguration serviceAccountConfiguration =

--- a/src/test/java/com/hartwig/platinum/kubernetes/KubernetesClusterTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/KubernetesClusterTest.java
@@ -3,6 +3,7 @@ package com.hartwig.platinum.kubernetes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,28 +41,29 @@ public class KubernetesClusterTest {
     private JobScheduler scheduler;
     private PipelineConfigMapBuilder configMaps;
     private ImmutablePlatinumConfiguration.Builder configBuilder;
+    private ArgumentCaptor<PipelineJob> jobCaptor;
 
     @Before
     public void setUp() {
         scheduler = mock(JobScheduler.class);
         configMaps = mock(PipelineConfigMapBuilder.class);
         SampleInput tumor = SampleInput.builder().name("tumor-a").build();
-        PipelineInput input1 = PipelineInput.builder().setName("setName").tumor(tumor).build();
+        PipelineInput input1 = PipelineInput.builder().setName("setName").tumor(tumor)/*.reference(reference)*/.build();
         pipelineInputs = List.of(() -> input1);
         when(configMaps.forSample(any(), any())).thenReturn(new VolumeBuilder().withName(CONFIG).build());
         ServiceAccountConfiguration serviceAccountConfiguration =
                 ServiceAccountConfiguration.builder().kubernetesServiceAccount("platinum-sa").gcpEmailAddress("e@mail.com").build();
         ImmutableGcpConfiguration gcpConfiguration = GcpConfiguration.builder().project("project").region("region").build();
         configBuilder = PlatinumConfiguration.builder().gcp(gcpConfiguration).serviceAccount(serviceAccountConfiguration);
+        jobCaptor = ArgumentCaptor.forClass(PipelineJob.class);
     }
 
     @Test
     public void addsJksVolumeAndContainerIfPasswordSpecified() {
-        ArgumentCaptor<PipelineJob> job = ArgumentCaptor.forClass(PipelineJob.class);
         victim = victimise(configBuilder.keystorePassword("changeit").build());
         victim.submit();
-        verify(scheduler).submit(job.capture());
-        PipelineJob result = job.getValue();
+        verify(scheduler).submit(jobCaptor.capture());
+        PipelineJob result = jobCaptor.getValue();
         assertThat(result.getVolumes()).extracting(Volume::getName).contains("jks");
         assertThat(result.getContainer().getEnv()).hasSize(1);
         EnvVar env = result.getContainer().getEnv().get(0);
@@ -71,19 +73,17 @@ public class KubernetesClusterTest {
 
     @Test
     public void submitsJobsToTheScheduler() {
-        ArgumentCaptor<PipelineJob> job = ArgumentCaptor.forClass(PipelineJob.class);
         victimise(configBuilder.keystorePassword("changeit").build()).submit();
-        verify(scheduler).submit(job.capture());
-        assertThat(job.getAllValues().size()).isEqualTo(SAMPLES.size());
+        verify(scheduler).submit(jobCaptor.capture());
+        assertThat(jobCaptor.getAllValues().size()).isEqualTo(SAMPLES.size());
     }
 
     @Test
     public void addsConfigMapAndSecretVolumes() {
-        ArgumentCaptor<PipelineJob> job = ArgumentCaptor.forClass(PipelineJob.class);
         victim = victimise(configBuilder.build());
         victim.submit();
-        verify(scheduler).submit(job.capture());
-        assertThat(job.getValue().getVolumes()).extracting(Volume::getName).containsExactly(CONFIG);
+        verify(scheduler).submit(jobCaptor.capture());
+        assertThat(jobCaptor.getValue().getVolumes()).extracting(Volume::getName).containsExactly(CONFIG);
     }
 
     @Test
@@ -94,16 +94,49 @@ public class KubernetesClusterTest {
 
         when(configMaps.forSample("tumor-a", inputA)).thenReturn(new VolumeBuilder().withName("config-a").build());
         when(configMaps.forSample("tumor-b", inputB)).thenReturn(new VolumeBuilder().withName("config-b").build());
-        ArgumentCaptor<PipelineJob> job = ArgumentCaptor.forClass(PipelineJob.class);
         victimise(configBuilder.build()).submit();
-        verify(scheduler, times(2)).submit(job.capture());
-        List<PipelineJob> allJobs = job.getAllValues();
+        verify(scheduler, times(2)).submit(jobCaptor.capture());
+        List<PipelineJob> allJobs = jobCaptor.getAllValues();
         List<PipelineJob> jobsA = allJobs.stream().filter(j -> j.getName().equals("tumor-a-test")).collect(Collectors.toList());
         assertThat(jobsA.size()).isEqualTo(1);
         assertThat(jobsA.get(0).getVolumes().stream().filter(v -> v.getName().equals("config-a")).collect(Collectors.toList())).hasSize(1);
         List<PipelineJob> jobsB = allJobs.stream().filter(j -> j.getName().equals("tumor-b-test")).collect(Collectors.toList());
         assertThat(jobsB.size()).isEqualTo(1);
         assertThat(jobsB.get(0).getVolumes().stream().filter(v -> v.getName().equals("config-b")).collect(Collectors.toList())).hasSize(1);
+    }
+
+    @Test
+    public void usesReferenceSampleNameWhenTumorSampleUnspecified() {
+        PipelineInput input = PipelineInput.builder().setName("set").reference(SampleInput.builder().name("reference").build()).build();
+        pipelineInputs = List.of(() -> input);
+
+        victimise(configBuilder.build()).submit();
+        verify(scheduler).submit(jobCaptor.capture());
+        assertThat(jobCaptor.getAllValues().size()).isEqualTo(1);
+        PipelineJob job = jobCaptor.getValue();
+        assertThat(job.getName()).isEqualTo("reference-test");
+    }
+
+    @Test
+    public void usesTumorSampleNameWhenBothSamplesSpecified() {
+        PipelineInput input = PipelineInput.builder().setName("set").reference(SampleInput.builder().name("reference").build())
+                .tumor(SampleInput.builder().name("tumor").build()).build();
+        pipelineInputs = List.of(() -> input);
+
+        victimise(configBuilder.build()).submit();
+        verify(scheduler).submit(jobCaptor.capture());
+        assertThat(jobCaptor.getAllValues().size()).isEqualTo(1);
+        PipelineJob job = jobCaptor.getValue();
+        assertThat(job.getName()).isEqualTo("tumor-test");
+    }
+
+    @Test
+    public void ignoresSampleWhenNeitherTumorNorReferenceSpecified() {
+        PipelineInput input = PipelineInput.builder().setName("set").build();
+        pipelineInputs = List.of(() -> input);
+
+        victimise(configBuilder.build()).submit();
+        verify(scheduler, never()).submit(any());
     }
 
     private static ImmutableSampleArgument sample() {


### PR DESCRIPTION
This has likely been broken since the switch to PDL for pipeline inputs.

Also print something useful every time there is something wrong with the sample input, previously this would just provide really limited feedback.