### PR TITLE
DEV-3692 Update PDL with turquoise subject to support pipeline 5.33.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         </google-api-services-cloudresourcemanager.version>
         <google-api-services-container.version>v1beta1-rev20200724-1.30.10</google-api-services-container.version>
         <java-client.version>1.35.0</java-client.version>
-        <pdl.version>1.0.2</pdl.version>
+        <pdl.version>1.7.1</pdl.version>
         <semvar4j.version>3.1.0</semvar4j.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>4.3.1</mockito.version>

--- a/src/main/java/com/hartwig/platinum/PlatinumMain.java
+++ b/src/main/java/com/hartwig/platinum/PlatinumMain.java
@@ -1,5 +1,7 @@
 package com.hartwig.platinum;
 
+import static java.lang.String.format;
+
 import java.util.concurrent.Callable;
 
 import com.google.cloud.storage.StorageOptions;
@@ -24,7 +26,8 @@ import picocli.CommandLine.Option;
 
 public class PlatinumMain implements Callable<Integer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PlatinumMain.class);
-    private static final String MIN_PV5_VERSION = "5.33";
+    private static final String MIN_PV5_VERSION = "5.33.8";
+    private static final String MAX_PV5_VERSION = VersionCompatibility.UNLIMITED;
 
     @Option(names = { "-n" },
             required = true,
@@ -50,7 +53,7 @@ public class PlatinumMain implements Callable<Integer> {
             PlatinumConfiguration configuration = addRegionAndProject(PlatinumConfiguration.from(inputJson));
             Validation.apply(runName, configuration);
 
-            new VersionCompatibility(MIN_PV5_VERSION, VersionCompatibility.UNLIMITED, new PipelineVersion()).check(configuration.image());
+            new VersionCompatibility(MIN_PV5_VERSION, MAX_PV5_VERSION, new PipelineVersion()).check(configuration.image());
 
             String clusterName = configuration.cluster().orElse(runName);
             KubernetesClientProxy kubernetesClientProxy =

--- a/src/main/java/com/hartwig/platinum/pdl/ConvertFromGCSPaths.java
+++ b/src/main/java/com/hartwig/platinum/pdl/ConvertFromGCSPaths.java
@@ -34,9 +34,11 @@ public class ConvertFromGCSPaths implements PDLConversion {
                     final int tumorIndexReadOnly = tumorIndex;
                     if (tumor.bam().isPresent()) {
                         pairs.add(() -> PipelineInput.builder()
-                                .reference(sample.normal().map(n -> SampleInput.builder().name(n.name()).bam(n.bam()).build()))
+                                .reference(sample.normal()
+                                        .map(n -> SampleInput.builder().name(n.name()).turquoiseSubject(n.name()).bam(n.bam()).build()))
                                 .tumor(SampleInput.builder()
                                         .name(tumor.name())
+                                        .turquoiseSubject(tumor.name())
                                         .bam(tumor.bam())
                                         .primaryTumorDoids(sample.primaryTumorDoids())
                                         .build())
@@ -45,9 +47,10 @@ public class ConvertFromGCSPaths implements PDLConversion {
                     } else {
 
                         pairs.add(() -> PipelineInput.builder()
-                                .reference(sample.normal().map(n -> SampleInput.builder().name(n.name()).lanes(toLanes(n.fastq())).build()))
+                                .reference(sample.normal().map(n -> SampleInput.builder().name(n.name()).turquoiseSubject(n.name()).lanes(toLanes(n.fastq())).build()))
                                 .tumor(SampleInput.builder()
                                         .name(tumor.name())
+                                        .turquoiseSubject(tumor.name())
                                         .lanes(toLanes(tumor.fastq()))
                                         .primaryTumorDoids(sample.primaryTumorDoids())
                                         .build())
@@ -58,7 +61,7 @@ public class ConvertFromGCSPaths implements PDLConversion {
                 }
             } else if (sample.normal().isPresent()) {
                 pairs.add(() -> PipelineInput.builder()
-                        .reference(sample.normal().map(n -> SampleInput.builder().name(n.name()).lanes(toLanes(n.fastq())).build()))
+                        .reference(sample.normal().map(n -> SampleInput.builder().name(n.name()).turquoiseSubject(n.name()).lanes(toLanes(n.fastq())).build()))
                         .setName(sample.name())
                         .build());
             }


### PR DESCRIPTION
Not the nicest to just add `turquoiseSubject` in platinum, but avoids the need to update pipeline5 (again). Tested local build with colo mini from BAM and works (with pipeline5 image `5.33.8` and resources image `pipeline5-5-33-202310061256-202310061709-private`).