### PR TITLE
Support alpha and beta version in pipeline5 tag

### DIFF
--- a/src/main/java/com/hartwig/platinum/config/version/PipelineVersion.java
+++ b/src/main/java/com/hartwig/platinum/config/version/PipelineVersion.java
@@ -6,7 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PipelineVersion {
-    String padVersionStringToSemanticVersion(final String candidate) {
+    String padVersionStringToSemanticVersion(final String inputCandidate) {
+        String candidate = inputCandidate.replaceAll("-(alpha|beta).[0-9]+$", "");
         ArrayList<String> versionsGiven = new ArrayList<>(List.of(candidate.split("\\.")));
         if (versionsGiven.size() > 3) {
             throw new IllegalArgumentException(format("Unrecognised pipeline version string [%s]", candidate));

--- a/src/main/java/com/hartwig/platinum/config/version/PipelineVersion.java
+++ b/src/main/java/com/hartwig/platinum/config/version/PipelineVersion.java
@@ -4,11 +4,21 @@ import static java.lang.String.format;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class PipelineVersion {
-    String padVersionStringToSemanticVersion(final String inputCandidate) {
-        String candidate = inputCandidate.replaceAll("-(alpha|beta).[0-9]+$", "");
-        ArrayList<String> versionsGiven = new ArrayList<>(List.of(candidate.split("\\.")));
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:-((?:alpha|beta)(?:\\.[0-9]+)*))?$");
+    String padVersionStringToSemanticVersion(final String candidate) {
+        Matcher matcher = VERSION_PATTERN.matcher(candidate);
+        ArrayList<String> versionsGiven;
+
+        if (matcher.find()) {
+            versionsGiven = new ArrayList<>(List.of(matcher.group(1), matcher.group(2), matcher.group(3)));
+        } else {
+            versionsGiven = new ArrayList<>(List.of(candidate.split("\\.")));
+        }
+
         if (versionsGiven.size() > 3) {
             throw new IllegalArgumentException(format("Unrecognised pipeline version string [%s]", candidate));
         }


### PR DESCRIPTION
Platinum would not allow the use of pipeline5 builds with the new alpha/beta versioning. This strips the alpha/beta part out of the version to make it possible to use those during test phases.