### PR TITLE
INFRA-320 Use new hmf-api client with added datatypes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,14 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <picocli.version>4.2.0</picocli.version>
         <fabric8.version>5.3.2</fabric8.version>
-        <jackson.version>2.10.0</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
         <failsafe.version>2.0.1</failsafe.version>
         <google-api-services-iam.version>v1-rev20200709-1.30.10</google-api-services-iam.version>
         <google-api-services-cloudresourcemanager.version>v1-rev20200720-1.30.10
         </google-api-services-cloudresourcemanager.version>
         <google-api-services-container.version>v1beta1-rev20200724-1.30.10</google-api-services-container.version>
-        <java-client.version>3.5.5</java-client.version>
-        <pdl.version>1.7.1</pdl.version>
+        <java-client.version>3.7.0-beta.4</java-client.version>
+        <pdl.version>1.10.0</pdl.version>
         <semvar4j.version>3.1.0</semvar4j.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>4.3.1</mockito.version>

--- a/src/main/java/com/hartwig/platinum/pdl/ConvertForBiopsies.java
+++ b/src/main/java/com/hartwig/platinum/pdl/ConvertForBiopsies.java
@@ -37,7 +37,7 @@ public class ConvertForBiopsies implements PDLConversion {
         return configuration.sampleIds()
                 .stream()
                 .flatMap(biopsy -> sampleApi.callList(null, null, null, null, SampleType.TUMOR, biopsy, null).stream())
-                .flatMap(sample -> setApi.callList(null, sample.getId(), true).stream())
+                .flatMap(sample -> setApi.callList(null, null, sample.getId(), null, null, true).stream())
                 .flatMap(set -> runApi.callList(Status.VALIDATED, Ini.SOMATIC_INI, set.getId(), null, null, null, null, "RESEARCH", null)
                         .stream()
                         .filter(run -> run.getEndTime() != null)


### PR DESCRIPTION
These datatypes are required to allow rerunning Orange without rerunning SAGE.

The update of jackson is not required but I wanted to get rid of vulnerabilities warning...