### PR TITLE
INFRA-429 Update fabric8 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <failsafe.version>2.0.1</failsafe.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <picocli.version>4.2.0</picocli.version>
-        <fabric8.version>5.3.2</fabric8.version>
+        <fabric8.version>6.12.1</fabric8.version>
         <jackson.version>2.16.1</jackson.version>
         <failsafe.version>2.0.1</failsafe.version>
         <google-api-services-iam.version>v1-rev20200709-1.30.10</google-api-services-iam.version>

--- a/src/main/java/com/hartwig/platinum/kubernetes/JobSubmitter.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/JobSubmitter.java
@@ -7,9 +7,9 @@ import com.hartwig.platinum.kubernetes.pipeline.PipelineJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.batch.JobBuilder;
-import io.fabric8.kubernetes.api.model.batch.JobSpec;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
 
 public class JobSubmitter {
 

--- a/src/main/java/com/hartwig/platinum/kubernetes/KubernetesClientProxy.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/KubernetesClientProxy.java
@@ -18,8 +18,8 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.batch.JobList;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
+import io.fabric8.kubernetes.client.dsl.ServiceAccountResource;
 
 public class KubernetesClientProxy {
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesClientProxy.class);
@@ -88,7 +89,7 @@ public class KubernetesClientProxy {
         }
     }
 
-    public MixedOperation<ServiceAccount, ServiceAccountList, Resource<ServiceAccount>> serviceAccounts() {
+    public MixedOperation<ServiceAccount, ServiceAccountList, ServiceAccountResource> serviceAccounts() {
         return kubernetesClient.serviceAccounts();
     }
 

--- a/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineJob.java
+++ b/src/main/java/com/hartwig/platinum/kubernetes/pipeline/PipelineJob.java
@@ -12,9 +12,9 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecFluent;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.batch.JobSpec;
-import io.fabric8.kubernetes.api.model.batch.JobSpecBuilder;
-import io.fabric8.kubernetes.api.model.batch.JobSpecFluent;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpecBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpecFluent;
 
 public class PipelineJob implements KubernetesComponent<JobSpec> {
 
@@ -50,7 +50,8 @@ public class PipelineJob implements KubernetesComponent<JobSpec> {
     @Override
     public JobSpec asKubernetes() {
         JobSpecBuilder jobSpecBuilder = new JobSpecBuilder();
-        final PodTemplateSpecFluent.SpecNested<JobSpecFluent.TemplateNested<JobSpecBuilder>> dsl = jobSpecBuilder.withNewTemplate()
+        final PodTemplateSpecFluent<JobSpecFluent<JobSpecBuilder>.TemplateNested<JobSpecBuilder>>.SpecNested<JobSpecFluent<JobSpecBuilder>.TemplateNested<JobSpecBuilder>>
+                dsl = jobSpecBuilder.withNewTemplate()
                 .withNewSpec()
                 .withContainers(container)
                 .withRestartPolicy("Never")

--- a/src/main/java/com/hartwig/platinum/scheduling/ConstantJobCountScheduler.java
+++ b/src/main/java/com/hartwig/platinum/scheduling/ConstantJobCountScheduler.java
@@ -10,7 +10,7 @@ import com.hartwig.platinum.kubernetes.pipeline.PipelineJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.api.model.batch.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;

--- a/src/test/java/com/hartwig/platinum/kubernetes/JobSubmitterTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/JobSubmitterTest.java
@@ -17,11 +17,11 @@ import com.hartwig.platinum.kubernetes.pipeline.PipelineJob;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.batch.JobBuilder;
-import io.fabric8.kubernetes.api.model.batch.JobCondition;
-import io.fabric8.kubernetes.api.model.batch.JobSpec;
-import io.fabric8.kubernetes.api.model.batch.JobStatus;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
 

--- a/src/test/java/com/hartwig/platinum/kubernetes/pipeline/PipelineJobTest.java
+++ b/src/test/java/com/hartwig/platinum/kubernetes/pipeline/PipelineJobTest.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.batch.JobSpec;
+import io.fabric8.kubernetes.api.model.batch.v1.JobSpec;
 
 public class PipelineJobTest {
     private PipelineJob victim;

--- a/src/test/java/com/hartwig/platinum/scheduling/ConstantJobCountSchedulerTest.java
+++ b/src/test/java/com/hartwig/platinum/scheduling/ConstantJobCountSchedulerTest.java
@@ -16,9 +16,9 @@ import com.hartwig.platinum.kubernetes.pipeline.PipelineJob;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.fabric8.kubernetes.api.model.batch.Job;
-import io.fabric8.kubernetes.api.model.batch.JobCondition;
-import io.fabric8.kubernetes.api.model.batch.JobStatus;
+import io.fabric8.kubernetes.api.model.batch.v1.Job;
+import io.fabric8.kubernetes.api.model.batch.v1.JobCondition;
+import io.fabric8.kubernetes.api.model.batch.v1.JobStatus;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;


### PR DESCRIPTION
Not sure why but I ran into issues with running platinum (`./platinum run`):
``` 
Exception in thread "main" java.lang.NoSuchMethodError: org.yaml.snakeyaml.constructor.SafeConstructor: method 'void <init>()' not found
```
This solves it by updating to latest `fabric8`. Cloud build of platinum ran succesfully (5.34.1-beta.4).